### PR TITLE
updating lint_dir to lint .qmd files by default

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -128,7 +128,8 @@ lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = 
 lint_dir <- function(path = ".", ...,
                      relative_path = TRUE,
                      exclusions = list("renv", "packrat"),
-                     pattern = rex(".", one_of("Rr"), or("", "html", "md", "nw", "rst", "tex", "txt"), end),
+                     pattern = rex(".", or(group(one_of("Rr"), or("", "html", "md", "nw", "rst", "tex", "txt")),
+                                           group(one_of("Qq"), "md")), end),
                      parse_settings = TRUE,
                      show_progress = NULL) {
   if (has_positional_logical(list(...))) {


### PR DESCRIPTION
Updating default of 'pattern' argument to match .qmd files, in keeping with functionality described in documentation.